### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,7 +8,7 @@ class Item < ApplicationRecord
   has_one_attached :image
 
   belongs_to :user
-  has_one :purchase
+  # has_one :purchase
 
   # 空の投稿を保存できないようにする
   validates :title, :summary, :price, :image, presence: true

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,6 +8,7 @@ class Item < ApplicationRecord
   has_one_attached :image
 
   belongs_to :user
+  has_one :purchase
 
   # 空の投稿を保存できないようにする
   validates :title, :summary, :price, :image, presence: true

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1,5 +1,5 @@
 class Purchase < ApplicationRecord
-  belongs_to :user
-  belongs_to :item
+  # belongs_to :user
+  # belongs_to :item
   # has_one :destination (商品購入機能実装時にコメントアウト解除)
 end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1,0 +1,5 @@
+class Purchase < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+  # has_one :destination (商品購入機能実装時にコメントアウト解除)
+end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,9 +131,9 @@
 
     <%# 商品が存在する場合 %>
     <% if @items.any? %>
-      <li class='list'>
-        <% @items.each do |item| %>
-         <%= link_to item_path(item) do %>
+      <% @items.each do |item| %>
+        <li class='list'>
+          <%= link_to item_path(item) do %>
           <div class='item-img-content'>
           <%= image_tag item.image.variant(resize: '229.41x229.41'), class: "item-img" if item.image.attached? %>
 
@@ -157,9 +157,9 @@
             </div>
           </div>
           </div>
-         <% end %>
-        <% end %>
-      </li>
+          <% end %>
+        </li>
+      <% end %>
 
     <%# 商品がない場合 %>
     <% else %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,6 +133,7 @@
     <% if @items.any? %>
       <li class='list'>
         <% @items.each do |item| %>
+         <%= link_to item_path(item) do %>
           <div class='item-img-content'>
           <%= image_tag item.image.variant(resize: '229.41x229.41'), class: "item-img" if item.image.attached? %>
 
@@ -156,6 +157,7 @@
             </div>
           </div>
           </div>
+         <% end %>
         <% end %>
       </li>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,67 +4,67 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.title %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image.variant(resize: '667.2 x 500'), class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
+      <%# <div class="sold-out">
         <span>Sold Out!!</span>
-      </div>
+      </div> %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+   <% if user_signed_in? && @item.purchase.blank? %>
+     <% if current_user.id == @item.user_id %>
+       <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+       <p class="or-text">or</p>
+       <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+     
+     <% else %>
 
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+     <% end %>
+   <% end %>
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.summary %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery_time.name %></td>
         </tr>
       </tbody>
     </table>
@@ -103,9 +103,9 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
+
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
     </div>
 
 
-   <% if user_signed_in? && @item.purchase.blank? %>
+   <% if user_signed_in? %>
      <% if current_user.id == @item.user_id %>
        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
        <p class="or-text">or</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/db/migrate/20240224090226_create_purchases.rb
+++ b/db/migrate/20240224090226_create_purchases.rb
@@ -1,0 +1,9 @@
+class CreatePurchases < ActiveRecord::Migration[7.0]
+  def change
+    create_table :purchases do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_17_052447) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_24_090226) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -54,6 +54,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_17_052447) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "purchases", charset: "utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_purchases_on_item_id"
+    t.index ["user_id"], name: "index_purchases_on_user_id"
+  end
+
   create_table "users", charset: "utf8", force: :cascade do |t|
     t.string "nickname", null: false
     t.string "email", default: "", null: false
@@ -75,4 +84,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_17_052447) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "purchases", "items"
+  add_foreign_key "purchases", "users"
 end

--- a/spec/factories/purchases.rb
+++ b/spec/factories/purchases.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :purchase do
+  end
+end

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Purchase, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What
商品詳細表示機能の実装

# Why
出品された商品の詳細を見られるようにするため。


1. ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
[https://gyazo.com/25e1627cd976eaf4b449f3ce111f7286](url)

2. ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
[https://gyazo.com/1eff74284d7924574b9ed8877f8389a9](url)

3. ログアウト状態で、商品詳細ページへ遷移した動画
[https://gyazo.com/1a4a0cb5d50309152ed7409a8ceb9892](url)